### PR TITLE
Implement persistent multi-project chat memory

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -139,7 +139,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const res = await fetch('/api/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ project: activeProject, messages: msgs })
+        body: JSON.stringify({ project: activeProject, message: content })
       });
       const data = await res.json();
       msgs.push({ role: 'assistant', content: data.reply });

--- a/memory/chat_memory.json
+++ b/memory/chat_memory.json
@@ -1,5 +1,14 @@
 {
-  "remote100k": {"messages": [], "instructions": "Use navy/gold/white. Slideshow format only. CTA slide at the end."},
-  "tradeview_ai": {"messages": [], "instructions": "Use navy/orange. Posts are for service contractors. Highlight automation benefits."},
-  "app_304": {"messages": [], "instructions": ""}
+  "remote100k": {
+    "messages": [],
+    "instructions": "Use navy/gold/white. All posts are slideshows. Add CTA slides. Use hook-based captions."
+  },
+  "tradeview_ai": {
+    "messages": [],
+    "instructions": "Use navy/orange. Speak to blue-collar contractors. Mention automations like Call Rescue and Auto Reviews. CTA = 'DM DEMO'"
+  },
+  "app_304": {
+    "messages": [],
+    "instructions": "Use black/masculine tone. App is for voting on dating profiles. Use bold, edgy, funny tone."
+  }
 }


### PR DESCRIPTION
## Summary
- update `memory/chat_memory.json` with brand instructions
- handle persistent memory in `agent.py` and log message count
- send only new message in frontend

## Testing
- `python3 -m py_compile agent.py`

------
https://chatgpt.com/codex/tasks/task_e_688779ffaf108326be481d99851df5fa