### PR TITLE
Fix chat API fetch and add Flask endpoint

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -1,0 +1,48 @@
+from flask import Flask, request, jsonify
+from pathlib import Path
+import json
+import os
+from dotenv import load_dotenv
+from openai import OpenAI
+
+load_dotenv()
+
+client = OpenAI()
+
+BASE_DIR = Path(__file__).resolve().parent
+MEMORY_FILE = BASE_DIR / 'memory' / 'chat_memory.json'
+
+app = Flask(__name__)
+
+@app.route('/api/chat', methods=['POST'])
+def chat():
+    data = request.get_json(force=True)
+    project = data.get('project')
+    message = data.get('message')
+    app.logger.info('POST /api/chat called for %s', project)
+    if not project or not message:
+        return jsonify({'error': 'Missing project or message'}), 400
+    memory = {}
+    if MEMORY_FILE.exists():
+        with open(MEMORY_FILE, 'r', encoding='utf-8') as f:
+            memory = json.load(f)
+    instructions = memory.get(project, {}).get('instructions', '')
+    history = memory.get(project, {}).get('messages', [])
+    messages = ([{'role': 'system', 'content': instructions}] +
+                history + [{'role': 'user', 'content': message}])
+    try:
+        response = client.chat.completions.create(model='gpt-4', messages=messages)
+        reply = response.choices[0].message.content
+    except Exception as e:
+        app.logger.error('Error from OpenAI: %s', e)
+        return jsonify({'error': str(e)}), 500
+    memory.setdefault(project, {}).setdefault('messages', [])
+    memory[project]['messages'] = history + [{'role': 'user', 'content': message}, {'role': 'assistant', 'content': reply}]
+    MEMORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(MEMORY_FILE, 'w', encoding='utf-8') as f:
+        json.dump(memory, f, indent=2)
+    return jsonify({'reply': reply})
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', '8000'))
+    app.run(host='0.0.0.0', port=port)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -136,7 +136,7 @@ document.addEventListener('DOMContentLoaded', () => {
     renderChat();
     chatInput.value = '';
     try {
-      const res = await fetch('/api/chat', {
+      const res = await fetch('https://gpt-agent-core-production.up.railway.app/api/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ project: activeProject, message: content })

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 python-dotenv
 openai
+
+flask


### PR DESCRIPTION
## Summary
- update `frontend/app.js` to call the production `/api/chat` URL
- add Flask server with `/api/chat` route
- log each POST request to the chat endpoint
- include Flask in requirements

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6887821ae60c8326a694ba7facbca43c