### PR TITLE
Fix minimal Flask server

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,48 +1,23 @@
 from flask import Flask, request, jsonify
-from pathlib import Path
-import json
-import os
-from dotenv import load_dotenv
-from openai import OpenAI
-
-load_dotenv()
-
-client = OpenAI()
-
-BASE_DIR = Path(__file__).resolve().parent
-MEMORY_FILE = BASE_DIR / 'memory' / 'chat_memory.json'
 
 app = Flask(__name__)
 
+
+@app.route('/')
+def index() -> str:
+    """Default route used as a health check."""
+    return "GPT Agent is running"
+
+
 @app.route('/api/chat', methods=['POST'])
 def chat():
+    """Return a dummy chat response."""
     data = request.get_json(force=True)
-    project = data.get('project')
     message = data.get('message')
-    app.logger.info('POST /api/chat called for %s', project)
-    if not project or not message:
-        return jsonify({'error': 'Missing project or message'}), 400
-    memory = {}
-    if MEMORY_FILE.exists():
-        with open(MEMORY_FILE, 'r', encoding='utf-8') as f:
-            memory = json.load(f)
-    instructions = memory.get(project, {}).get('instructions', '')
-    history = memory.get(project, {}).get('messages', [])
-    messages = ([{'role': 'system', 'content': instructions}] +
-                history + [{'role': 'user', 'content': message}])
-    try:
-        response = client.chat.completions.create(model='gpt-4', messages=messages)
-        reply = response.choices[0].message.content
-    except Exception as e:
-        app.logger.error('Error from OpenAI: %s', e)
-        return jsonify({'error': str(e)}), 500
-    memory.setdefault(project, {}).setdefault('messages', [])
-    memory[project]['messages'] = history + [{'role': 'user', 'content': message}, {'role': 'assistant', 'content': reply}]
-    MEMORY_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(MEMORY_FILE, 'w', encoding='utf-8') as f:
-        json.dump(memory, f, indent=2)
-    return jsonify({'reply': reply})
+    if not message:
+        return jsonify({'error': 'Missing message'}), 400
+    return jsonify({'reply': 'This is a test response.'})
+
 
 if __name__ == '__main__':
-    port = int(os.environ.get('PORT', '8000'))
-    app.run(host='0.0.0.0', port=port)
+    app.run(host='0.0.0.0', port=8080)


### PR DESCRIPTION
## Summary
- simplify `agent.py` to provide minimal Flask server for Railway

## Testing
- `python3 -m py_compile agent.py`
- `python3 agent.py & sleep 2; curl -s http://localhost:8080/; curl -s -X POST -H 'Content-Type: application/json' -d '{"message":"hi"}' http://localhost:8080/api/chat; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_688786fb35dc8326bc5a5e024cf760c8