### PR TITLE
Implement OpenAI-backed chat endpoint

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -136,13 +136,13 @@ document.addEventListener('DOMContentLoaded', () => {
     renderChat();
     chatInput.value = '';
     try {
-      const res = await fetch('https://gpt-agent-core-production.up.railway.app/api/chat', {
+      const res = await fetch('/api/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ project: activeProject, message: content })
+        body: JSON.stringify({ message: content })
       });
       const data = await res.json();
-      msgs.push({ role: 'assistant', content: data.reply });
+      msgs.push({ role: 'assistant', content: data.response });
       conversations[activeProject] = msgs;
       renderChat();
       console.log(`✅ Chat + Memory working for ${activeProject}`);


### PR DESCRIPTION
## Summary
- wire up `/api/chat` to OpenAI API
- log chat interactions in `chat_history.json`
- update frontend chat call for new API response

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile agent.py`
- `curl -X POST -H 'Content-Type: application/json' -d '{"message":"Hello"}' http://localhost:8000/api/chat` *(fails: Connection error due to blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_68879047455083268a40f52587e56fa1