### PR TITLE
Update README for service deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ gpt-agent-core/
 
 ## Frontend
 
-The dashboard lives in the `frontend/` directory and is intentionally implemented without external build tools such as React or Vite.  This makes it lightweight and easy to run in any environment, even when package installation is restricted.  Tailwind CSS is included via CDN for rapid styling, and the interface is composed of vanilla HTML and JavaScript.
+The dashboard lives in the `frontend/` directory and is a small [React](https://react.dev/) application built with [Vite](https://vitejs.dev/).  The repository already contains the compiled files under `frontend/dist`, so you can run the server without installing any Node tooling.  If you want to modify the UI, install the dependencies in `frontend/` and rebuild:
+
+```bash
+cd frontend
+npm install
+npm run build
+```
+
+The build output will be placed in `frontend/dist` and served by the Python backend.
 
 Key interface elements include:
 
@@ -52,6 +60,22 @@ python3 agent.py
 The server will start on port 8000 by default (or whatever value you set in the
 `PORT` environment variable).  Visit `http://localhost:8000` in your browser to
 load the dashboard.
+
+### Running 24/7
+
+If you want the agent to run continuously on a server you can install it as a
+`systemd` service.  A sample unit file is provided in `deploy/agent.service`.
+Edit the paths and user, copy it to `/etc/systemd/system/`, then enable and
+start the service:
+
+```bash
+sudo cp deploy/agent.service /etc/systemd/system/gpt-agent.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now gpt-agent.service
+```
+
+The dashboard will then be accessible on the configured port whenever the
+machine is running.
 
 ### API Endpoints
 

--- a/deploy/agent.service
+++ b/deploy/agent.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=GPT Agent Core service
+After=network.target
+
+[Service]
+Type=simple
+User=YOUR_USER
+WorkingDirectory=/path/to/gpt-agent-core
+EnvironmentFile=/path/to/gpt-agent-core/.env
+ExecStart=/usr/bin/python3 /path/to/gpt-agent-core/agent.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- clarify that the dashboard uses React/Vite and show how to rebuild it
- document how to run the agent as a `systemd` service
- provide a sample `deploy/agent.service` unit file

## Testing
- `python3 -m py_compile agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6887c2468e188326a004e682ecd1cffa