### PR TITLE
Refactor frontend with ChatGPT-style UI and live webview

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -104,7 +104,7 @@ function App() {
         return
       }
       setBrands(b => [...b, { key: data.key, name: data.name }])
-    } catch (e) {
+    } catch {
       alert('Failed to create project')
     }
   }

--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import TypingDots from './TypingDots.jsx'
 
 /**
  * ChatBox renders conversation bubbles and a sticky input field.
@@ -6,8 +7,7 @@ import { useEffect, useRef, useState } from 'react'
  * alternate alignment based on sender and display a simple typing
  * animation while awaiting a response.
  */
-export default function ChatBox({ sendMessage }) {
-  const [messages, setMessages] = useState([])
+export default function ChatBox({ messages, setMessages, sendMessage }) {
   const [input, setInput] = useState('')
   const pendingRef = useRef(null)
   const endRef = useRef(null)
@@ -22,8 +22,8 @@ export default function ChatBox({ sendMessage }) {
     if (!text) return
     setInput('')
     setMessages(m => [...m, { role: 'user', content: text }])
-    // Add placeholder
-    const placeholder = { role: 'assistant', content: '...', pending: true }
+    // Add placeholder for typing indicator
+    const placeholder = { role: 'assistant', content: '', pending: true }
     setMessages(m => {
       const arr = [...m, placeholder]
       pendingRef.current = arr.length - 1
@@ -80,7 +80,7 @@ export default function ChatBox({ sendMessage }) {
                 ' px-4 py-2 rounded-lg max-w-[75%] whitespace-pre-wrap'
               }
             >
-              {m.pending ? <span className="animate-pulse">{m.content}</span> : m.content}
+              {m.pending ? <TypingDots /> : m.content}
               {m.timestamp && (
                 <div className="text-xs text-right opacity-50 mt-1">
                   {new Date(m.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}

--- a/frontend/src/components/LiveWebView.jsx
+++ b/frontend/src/components/LiveWebView.jsx
@@ -1,0 +1,17 @@
+/**
+ * LiveWebView displays current task status with a spinner when running.
+ */
+export default function LiveWebView({ status, running }) {
+  return (
+    <aside className="w-full md:w-64 border-t md:border-t-0 md:border-l border-gray-200 dark:border-gray-800 p-4 bg-white dark:bg-gray-900 flex items-center justify-center">
+      {running ? (
+        <div className="flex items-center gap-2 text-sm">
+          <div className="w-4 h-4 border-2 border-gray-300 dark:border-gray-600 border-t-transparent rounded-full animate-spin" />
+          <span>{status}</span>
+        </div>
+      ) : (
+        <div className="text-sm text-gray-500 dark:text-gray-400">{status}</div>
+      )}
+    </aside>
+  )
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -12,7 +12,8 @@ const DEFAULT_BRANDS = [
   { key: 'tradeview_ai', name: 'Tradeview AI' },
   { key: 'app_304', name: '304 App' },
 ]
-const PROJECT_ITEMS = ['Slides', 'Captions', 'Media Uploads', 'Chat Logs']
+// Items shown under each project folder
+const PROJECT_ITEMS = ['Slides', 'Captions', 'Files', 'Tasks', 'Comments']
 
 /**
  * Sidebar component containing project folders.  Supports
@@ -43,14 +44,14 @@ export default function Sidebar({
   return (
     <aside
       className={
-        `flex-shrink-0 w-60 h-full bg-gray-900 text-gray-100 p-3 ` +
+        `fixed inset-y-0 left-0 z-20 w-60 bg-gray-900 text-gray-100 p-3 ` +
         `border-r border-gray-800 overflow-y-auto transform ` +
         `${sidebarOpen ? 'translate-x-0' : '-translate-x-full'} ` +
         `sm:translate-x-0 transition-transform duration-200 ease-in-out`
       }
     >
       <div className="mb-4 text-lg font-semibold">Projects</div>
-      {brands.map((b, idx) => (
+      {brands.map(b => (
         <div key={b.key} className="mb-1">
           <button
             onClick={() => toggleBrand(b.key)}
@@ -76,7 +77,10 @@ export default function Sidebar({
             {PROJECT_ITEMS.map(item => (
               <li key={item}>
                 <button
-                  onClick={() => onSelect(b.key, item)}
+                  onClick={() => {
+                    onSelect(b.key, item)
+                    setSidebarOpen(false)
+                  }}
                   className="flex items-center gap-2 w-full px-2 py-1 text-sm rounded hover:bg-gray-800"
                 >
                   <DocumentTextIcon className="w-4 h-4" /> {item}

--- a/frontend/src/components/TypingDots.jsx
+++ b/frontend/src/components/TypingDots.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+/**
+ * Three-dot typing indicator using Tailwind animations.
+ */
+export default function TypingDots() {
+  return (
+    <span className="flex items-center space-x-1">
+      <span className="w-2 h-2 bg-current rounded-full animate-bounce" />
+      <span className="w-2 h-2 bg-current rounded-full animate-bounce [animation-delay:0.2s]" />
+      <span className="w-2 h-2 bg-current rounded-full animate-bounce [animation-delay:0.4s]" />
+    </span>
+  )
+}

--- a/frontend/src/components/UploadPanel.jsx
+++ b/frontend/src/components/UploadPanel.jsx
@@ -20,7 +20,7 @@ export default function UploadPanel({ onUpload }) {
     e.preventDefault()
     setDragging(true)
   }
-  function handleDragLeave(e) {
+  function handleDragLeave() {
     setDragging(false)
   }
   function handleChange(e) {

--- a/frontend/src/pages/index.jsx
+++ b/frontend/src/pages/index.jsx
@@ -1,13 +1,12 @@
 import { useState } from 'react'
 import Sidebar from '../components/Sidebar.jsx'
 import ChatBox from '../components/ChatBox.jsx'
-import UploadPanel from '../components/UploadPanel.jsx'
-import AgentStatusPanel from '../components/AgentStatusPanel.jsx'
+import LiveWebView from '../components/LiveWebView.jsx'
 import ToggleDarkMode from '../components/ToggleDarkMode.jsx'
 
 /**
- * Main page that composes the sidebar, chat, upload panel and
- * status panel.  Handles project selection and file uploads.
+ * Main page that composes the sidebar, chat panel and live webview.
+ * Handles project selection and dark mode.
  */
 export default function IndexPage() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
@@ -17,33 +16,40 @@ export default function IndexPage() {
     { key: 'app_304', name: '304 App' },
   ])
   const [current, setCurrent] = useState({ project: '', item: '' })
+  const [conversations, setConversations] = useState({})
+  const [task, setTask] = useState({ text: 'Waiting for input…', running: false })
+
+  const currentKey = `${current.project}/${current.item}`
+
+  function updateMessages(updater) {
+    setConversations(prev => {
+      const list = prev[currentKey] || []
+      const updated = typeof updater === 'function' ? updater(list) : updater
+      return { ...prev, [currentKey]: updated }
+    })
+  }
 
   async function sendMessage(text) {
+    const lower = text.toLowerCase()
+    let status
+    if (lower.includes('tiktok')) status = 'Ajax is scanning TikTok comments…'
+    else if (lower.includes('slideshow')) status = 'Generating slideshow…'
+    else status = 'Ajax is thinking…'
+
+    setTask({ text: status, running: true })
+
     const res = await fetch('/api/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ message: text }),
     })
-    return res.json()
-  }
-
-  async function uploadFiles(files) {
-    const form = new FormData()
-    form.append('project', current.project || 'general')
-    for (const f of files) form.append('file', f)
-    await fetch('/api/upload', {
-      method: 'POST',
-      body: form,
-    })
+    const data = await res.json()
+    setTask({ text: 'Waiting for input…', running: false })
+    return data
   }
 
   return (
-    <div className="min-h-screen flex flex-col lg:flex-row bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-      {/* Mobile header */}
-      <header className="flex items-center justify-between p-3 lg:hidden bg-gray-900 text-gray-100">
-        <button onClick={() => setSidebarOpen(o => !o)} className="text-xl">☰</button>
-        <ToggleDarkMode />
-      </header>
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       <Sidebar
         brands={brands}
         onSelect={(project, item) => setCurrent({ project, item })}
@@ -51,19 +57,33 @@ export default function IndexPage() {
         sidebarOpen={sidebarOpen}
         setSidebarOpen={setSidebarOpen}
       />
-      {/* Main content area */}
-      <main className="flex-1 flex flex-col lg:flex-row h-[calc(100vh-3rem)] lg:h-screen">
-        <section className="flex-1 flex flex-col">
-          {/* Top bar for desktop */}
-          <div className="hidden lg:flex justify-between items-center p-3 border-b border-gray-200 dark:border-gray-800 bg-gray-900 text-gray-100">
-            <div className="text-xl font-semibold">Welcome Logan 👋</div>
-            <ToggleDarkMode />
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 sm:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+      <div className="flex flex-col md:ml-60 h-screen">
+        <header className="flex items-center justify-between p-3 border-b border-gray-200 dark:border-gray-800 md:border-b-0">
+          <button onClick={() => setSidebarOpen(true)} className="md:hidden">☰</button>
+          <div className="font-semibold truncate">
+            {current.project && current.item
+              ? `${brands.find(b => b.key === current.project)?.name || ''} / ${current.item}`
+              : 'Select a folder'}
           </div>
-          <ChatBox sendMessage={sendMessage} />
-          <UploadPanel onUpload={uploadFiles} />
-        </section>
-        <AgentStatusPanel />
-      </main>
+          <ToggleDarkMode />
+        </header>
+        <main className="flex-1 flex flex-col md:flex-row">
+          <section className="flex-1 flex flex-col">
+            <ChatBox
+              messages={conversations[currentKey] || []}
+              setMessages={updateMessages}
+              sendMessage={sendMessage}
+            />
+          </section>
+          <LiveWebView status={task.text} running={task.running} />
+        </main>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Revamp layout with fixed sidebar tabs and collapsible project sections
- Integrate ChatGPT-like chat box, typing indicator, and dark mode toggle
- Add live webview panel showing task status with spinner

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e8ac9e74883269932365007fa3e72