### PR TITLE
fix: improve sidebar layout and dark mode

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -44,10 +44,10 @@ export default function Sidebar({
   return (
     <aside
       className={
-        `fixed inset-y-0 left-0 z-20 w-60 bg-gray-900 text-gray-100 p-3 ` +
-        `border-r border-gray-800 overflow-y-auto transform ` +
-        `${sidebarOpen ? 'translate-x-0' : '-translate-x-full'} ` +
-        `sm:translate-x-0 transition-transform duration-200 ease-in-out`
+        `fixed top-0 left-0 z-20 w-60 h-screen bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100 p-3 ` +
+        `border-r border-gray-200 dark:border-gray-800 overflow-y-scroll transform ` +
+        `${sidebarOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0 ` +
+        `transition-transform duration-200 ease-in-out`
       }
     >
       <div className="mb-4 text-lg font-semibold">Projects</div>
@@ -55,7 +55,7 @@ export default function Sidebar({
         <div key={b.key} className="mb-1">
           <button
             onClick={() => toggleBrand(b.key)}
-            className="flex items-center justify-between w-full px-2 py-1 rounded hover:bg-gray-800"
+            className="flex items-center justify-between w-full px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800"
           >
             <span className="flex items-center gap-2">
               <FolderIcon className="w-5 h-5" />
@@ -81,7 +81,7 @@ export default function Sidebar({
                     onSelect(b.key, item)
                     setSidebarOpen(false)
                   }}
-                  className="flex items-center gap-2 w-full px-2 py-1 text-sm rounded hover:bg-gray-800"
+                  className="flex items-center gap-2 w-full px-2 py-1 text-sm rounded hover:bg-gray-200 dark:hover:bg-gray-800"
                 >
                   <DocumentTextIcon className="w-4 h-4" /> {item}
                 </button>
@@ -97,11 +97,11 @@ export default function Sidebar({
             value={newProjectName}
             onChange={e => setNewProjectName(e.target.value)}
             placeholder="New project"
-            className="flex-1 px-2 py-1 rounded bg-gray-800 text-sm focus:outline-none"
+            className="flex-1 px-2 py-1 rounded bg-gray-200 dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 focus:outline-none"
           />
           <button
             onClick={handleAdd}
-            className="p-2 rounded bg-gray-800 hover:bg-gray-700"
+            className="p-2 rounded bg-gray-200 dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-700"
           >
             <PlusIcon className="w-4 h-4" />
           </button>

--- a/frontend/src/pages/index.jsx
+++ b/frontend/src/pages/index.jsx
@@ -57,15 +57,22 @@ export default function IndexPage() {
         sidebarOpen={sidebarOpen}
         setSidebarOpen={setSidebarOpen}
       />
+      {!sidebarOpen && (
+        <button
+          onClick={() => setSidebarOpen(true)}
+          className="fixed top-3 left-3 z-30 md:hidden"
+        >
+          ☰
+        </button>
+      )}
       {sidebarOpen && (
         <div
-          className="fixed inset-0 bg-black/50 sm:hidden"
+          className="fixed inset-0 bg-black/50 md:hidden z-10"
           onClick={() => setSidebarOpen(false)}
         />
       )}
       <div className="flex flex-col md:ml-60 h-screen">
-        <header className="flex items-center justify-between p-3 border-b border-gray-200 dark:border-gray-800 md:border-b-0">
-          <button onClick={() => setSidebarOpen(true)} className="md:hidden">☰</button>
+        <header className="flex items-center justify-between py-3 pr-3 pl-12 md:pl-3 border-b border-gray-200 dark:border-gray-800 md:border-b-0">
           <div className="font-semibold truncate">
             {current.project && current.item
               ? `${brands.find(b => b.key === current.project)?.name || ''} / ${current.item}`


### PR DESCRIPTION
## Summary
- make sidebar fixed with 100vh height and internal scroll
- float hamburger toggle button and adjust header spacing
- update sidebar styles for Tailwind dark mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e8e6221648326b7a7907eacbde54f