### PR TITLE
Improve sidebar interactions and theming

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,7 +11,7 @@
       }
     </script>
   </head>
-  <body class="h-full">
+  <body class="h-full bg-gray-100 dark:bg-gray-900">
     <div id="root" class="h-full"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -56,7 +56,9 @@ function App() {
   const [isPresent, setIsPresent] = useState(() => true)
 
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark')
+    const dark = theme === 'dark'
+    document.documentElement.classList.toggle('dark', dark)
+    document.body.classList.toggle('dark', dark)
     localStorage.setItem('theme', theme)
   }, [theme])
 

--- a/frontend/src/Sidebar.jsx
+++ b/frontend/src/Sidebar.jsx
@@ -29,7 +29,7 @@ export default function Sidebar({
   const [active, setActive] = useState({ project: '', item: '' })
   return (
     <aside
-      className={`fixed sm:relative z-20 inset-y-0 left-0 w-64 bg-gray-800 text-white flex flex-col p-4 space-y-4 transition-all duration-300 ease-in-out overflow-y-auto ${sidebarOpen ? 'translate-x-0' : '-translate-x-full sm:translate-x-0'}`}
+      className={`fixed sm:relative z-20 inset-y-0 left-0 w-64 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white flex flex-col p-4 space-y-4 transition-all duration-300 ease-in-out ${sidebarOpen ? 'translate-x-0' : '-translate-x-full sm:translate-x-0'}`}
     >
       <div>
         <h1 className="text-xl font-bold">Welcome Logan 👋</h1>
@@ -38,20 +38,20 @@ export default function Sidebar({
         {brands.map(b => (
           <div key={b.key} className="space-y-1">
             <button
-              onClick={() => setOpenBrand(o => (o === b.key ? '' : b.key))}
-              className="w-full flex items-center justify-between px-2 py-1 rounded hover:bg-gray-700 transition"
+              onClick={() => {
+                setBrand(b.key)
+                setOpenBrand(o => (o === b.key ? '' : b.key))
+              }}
+              className="w-full flex items-center justify-between px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition"
             >
-              <span
-                className="flex items-center gap-2"
-                onClick={() => setBrand(b.key)}
-              >
-                <FolderIcon className="w-5 h-5" />
+              <span className="flex items-center gap-2">
+                <FolderIcon className="w-5 h-5 shrink-0" />
                 {b.name}
               </span>
               {openBrand === b.key ? (
-                <ChevronDownIcon className="w-4 h-4" />
+                <ChevronDownIcon className="w-4 h-4 shrink-0" />
               ) : (
-                <ChevronRightIcon className="w-4 h-4" />
+                <ChevronRightIcon className="w-4 h-4 shrink-0" />
               )}
             </button>
             <ul
@@ -64,13 +64,13 @@ export default function Sidebar({
                       setBrand(b.key)
                       setActive({ project: b.key, item })
                     }}
-                    className={`flex items-center gap-2 w-full px-2 py-1 rounded hover:bg-gray-700 ${
+                    className={`flex items-center gap-2 w-full px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 ${
                       active.project === b.key && active.item === item
-                        ? 'bg-gray-700 text-white'
-                        : 'text-gray-300'
+                        ? 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white'
+                        : 'text-gray-600 dark:text-gray-300'
                     }`}
                   >
-                    <DocumentTextIcon className="w-4 h-4" />
+                    <DocumentTextIcon className="w-4 h-4 shrink-0" />
                     <span>{item}</span>
                   </button>
                 </li>
@@ -80,17 +80,21 @@ export default function Sidebar({
         ))}
         <button
           onClick={addProject}
-          className="w-full flex items-center gap-1 font-semibold hover:bg-gray-700 rounded px-2 py-1 transition-all"
+          className="w-full flex items-center gap-1 font-semibold hover:bg-gray-200 dark:hover:bg-gray-700 rounded px-2 py-1 transition"
         >
-          <PlusIcon className="w-4 h-4" /> Add Project
+          <PlusIcon className="w-4 h-4 shrink-0" /> Add Project
         </button>
         <div className="space-y-1">
           <button
             onClick={() => setShowLinks(s => !s)}
-            className="w-full flex items-center justify-between font-semibold hover:bg-gray-700 rounded px-2 py-1 transition-all"
+            className="w-full flex items-center justify-between font-semibold hover:bg-gray-200 dark:hover:bg-gray-700 rounded px-2 py-1 transition"
           >
             <span>Link Accounts</span>
-            <PlusIcon className="w-4 h-4" />
+            {showLinks ? (
+              <ChevronDownIcon className="w-4 h-4 shrink-0" />
+            ) : (
+              <ChevronRightIcon className="w-4 h-4 shrink-0" />
+            )}
           </button>
           <ul className={`${showLinks ? 'max-h-40' : 'max-h-0'} overflow-hidden transition-all ml-4 text-xs space-y-1`}>
             {SOCIALS.map(s => (


### PR DESCRIPTION
## Summary
- shrink sidebar icons and make nested dropdowns responsive
- wire dark/light toggle to document body and adjust layout classes
- ensure sidebar controls remain visible without scrolling

## Testing
- `npm run lint`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e90cb2eac83268f5f56b4a45c9108