### PR TITLE
Fix sidebar height, toggle placement, and dark mode

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -44,8 +44,8 @@ export default function Sidebar({
   return (
     <aside
       className={
-        `fixed top-0 left-0 z-20 w-60 h-screen bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100 p-3 ` +
-        `border-r border-gray-200 dark:border-gray-800 overflow-y-scroll transform ` +
+        `fixed top-0 left-0 z-20 w-64 h-screen bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100 p-4 ` +
+        `border-r border-gray-200 dark:border-gray-800 overflow-y-auto transform ` +
         `${sidebarOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0 ` +
         `transition-transform duration-200 ease-in-out`
       }

--- a/frontend/src/components/ToggleDarkMode.jsx
+++ b/frontend/src/components/ToggleDarkMode.jsx
@@ -1,31 +1,17 @@
-import { useEffect, useState } from 'react'
-
 /**
  * Dark mode toggle component.  Displays a switch in the top‑right
- * corner and persists the user’s choice in localStorage.  This
- * component does not render anything on smaller devices when
- * embedded into the sidebar; instead, use it in your page layout.
+ * corner and relies on the parent component to persist the setting in
+ * localStorage.  This component does not render anything on smaller
+ * devices when embedded into the sidebar; instead, use it in your page
+ * layout.
  */
-export default function ToggleDarkMode() {
-  const [theme, setTheme] = useState(() => {
-    return localStorage.getItem('theme') || 'light'
-  })
-
-  useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark')
-    localStorage.setItem('theme', theme)
-  }, [theme])
-
-  function toggle() {
-    setTheme(t => (t === 'light' ? 'dark' : 'light'))
-  }
-
+export default function ToggleDarkMode({ darkMode, setDarkMode }) {
   return (
     <button
-      onClick={toggle}
+      onClick={() => setDarkMode(!darkMode)}
       className="text-sm px-3 py-2 rounded-md border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
     >
-      {theme === 'light' ? '🌙 Dark' : '☀️ Light'}
+      {darkMode ? '☀️ Light' : '🌙 Dark'}
     </button>
   )
 }

--- a/frontend/src/pages/index.jsx
+++ b/frontend/src/pages/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Sidebar from '../components/Sidebar.jsx'
 import ChatBox from '../components/ChatBox.jsx'
 import LiveWebView from '../components/LiveWebView.jsx'
@@ -9,6 +9,7 @@ import ToggleDarkMode from '../components/ToggleDarkMode.jsx'
  * Handles project selection and dark mode.
  */
 export default function IndexPage() {
+  const [darkMode, setDarkMode] = useState(() => localStorage.getItem('darkMode') === 'true')
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [brands, setBrands] = useState([
     { key: 'remote100k', name: 'Remote100K' },
@@ -48,48 +49,53 @@ export default function IndexPage() {
     return data
   }
 
+  useEffect(() => {
+    localStorage.setItem('darkMode', darkMode ? 'true' : 'false')
+  }, [darkMode])
+
   return (
-    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-      <Sidebar
-        brands={brands}
-        onSelect={(project, item) => setCurrent({ project, item })}
-        onAddProject={p => setBrands(b => [...b, p])}
-        sidebarOpen={sidebarOpen}
-        setSidebarOpen={setSidebarOpen}
-      />
-      {!sidebarOpen && (
+    <div className={darkMode ? 'dark' : ''}>
+      <div className="min-h-screen bg-white text-black dark:bg-gray-900 dark:text-white">
+        <Sidebar
+          brands={brands}
+          onSelect={(project, item) => setCurrent({ project, item })}
+          onAddProject={p => setBrands(b => [...b, p])}
+          sidebarOpen={sidebarOpen}
+          setSidebarOpen={setSidebarOpen}
+        />
         <button
-          onClick={() => setSidebarOpen(true)}
-          className="fixed top-3 left-3 z-30 md:hidden"
+          onClick={() => setSidebarOpen(!sidebarOpen)}
+          aria-label="Toggle sidebar"
+          className="fixed top-4 left-4 z-50 md:hidden p-2 bg-white dark:bg-gray-800 rounded shadow"
         >
           ☰
         </button>
-      )}
-      {sidebarOpen && (
-        <div
-          className="fixed inset-0 bg-black/50 md:hidden z-10"
-          onClick={() => setSidebarOpen(false)}
-        />
-      )}
-      <div className="flex flex-col md:ml-60 h-screen">
-        <header className="flex items-center justify-between py-3 pr-3 pl-12 md:pl-3 border-b border-gray-200 dark:border-gray-800 md:border-b-0">
-          <div className="font-semibold truncate">
-            {current.project && current.item
-              ? `${brands.find(b => b.key === current.project)?.name || ''} / ${current.item}`
-              : 'Select a folder'}
-          </div>
-          <ToggleDarkMode />
-        </header>
-        <main className="flex-1 flex flex-col md:flex-row">
-          <section className="flex-1 flex flex-col">
-            <ChatBox
-              messages={conversations[currentKey] || []}
-              setMessages={updateMessages}
-              sendMessage={sendMessage}
-            />
-          </section>
-          <LiveWebView status={task.text} running={task.running} />
-        </main>
+        {sidebarOpen && (
+          <div
+            className="fixed inset-0 bg-black/50 md:hidden z-10"
+            onClick={() => setSidebarOpen(false)}
+          />
+        )}
+        <div className="flex flex-col md:ml-64 h-screen">
+          <header className="flex items-center justify-between py-3 pr-3 pl-16 md:pl-3 border-b border-gray-200 dark:border-gray-800 md:border-b-0">
+            <div className="font-semibold truncate">
+              {current.project && current.item
+                ? `${brands.find(b => b.key === current.project)?.name || ''} / ${current.item}`
+                : 'Select a folder'}
+            </div>
+            <ToggleDarkMode darkMode={darkMode} setDarkMode={setDarkMode} />
+          </header>
+          <main className="flex-1 flex flex-col md:flex-row">
+            <section className="flex-1 flex flex-col">
+              <ChatBox
+                messages={conversations[currentKey] || []}
+                setMessages={updateMessages}
+                sendMessage={sendMessage}
+              />
+            </section>
+            <LiveWebView status={task.text} running={task.running} />
+          </main>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- keep sidebar full height and make its contents scrollable
- pin the sidebar toggle button to the viewport top-left
- implement Tailwind dark mode with localStorage persistence

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_688e956069248326a6405f47a0a941f1