### PR TITLE
feat: add multi-agent dashboard with CRM and memory

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core package for Ajax multi-agent system."""

--- a/core/agents/dev.py
+++ b/core/agents/dev.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from .base_agent import BaseAgent
+
+
+class DevAgent(BaseAgent):
+    """Agent for code generation and editing."""
+
+    def run(self, action: str, payload: Optional[str] = None) -> str:
+        if action == "react_component":
+            return self.write_react_component(payload)
+        if action == "fix_backend_bug":
+            return self.fix_backend_bug(payload)
+        if action == "tailwind_card":
+            return self.generate_tailwind_card(payload)
+        return f"[DevAgent] Unknown action: {action}"
+
+    def write_react_component(self, spec: Optional[str]) -> str:
+        return f"[DevAgent] Writing React component for {spec or 'feature'}"
+
+    def fix_backend_bug(self, description: Optional[str]) -> str:
+        return f"[DevAgent] Fixing backend bug: {description or 'issue'}"
+
+    def generate_tailwind_card(self, spec: Optional[str]) -> str:
+        return f"[DevAgent] Generating Tailwind card for {spec or 'content'}"
+
+    def handle_task(self, task: str) -> str:
+        return self.run(task)

--- a/core/agents/growth.py
+++ b/core/agents/growth.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from .base_agent import BaseAgent
+
+
+class GrowthAgent(BaseAgent):
+    """Automation agent for social media growth."""
+
+    def run(self, action: str, payload: Optional[str] = None) -> str:
+        if action == "slideshow":
+            return self.generate_slideshow(payload)
+        if action == "dm":
+            return self.send_follow_up_dm(payload)
+        if action == "scrape":
+            return self.scrape_competitor(payload)
+        return f"[GrowthAgent] Unknown action: {action}"
+
+    def generate_slideshow(self, topic: Optional[str]) -> str:
+        return f"[GrowthAgent] Creating slideshow for {topic or 'general topic'}"
+
+    def send_follow_up_dm(self, account: Optional[str]) -> str:
+        return f"[GrowthAgent] Sending follow-up DM to {account or 'target'}"
+
+    def scrape_competitor(self, account: Optional[str]) -> str:
+        return f"[GrowthAgent] Scraping competitor {account or 'profile'}"
+
+    def handle_task(self, task: str) -> str:
+        return self.run(task)

--- a/core/agents/ops.py
+++ b/core/agents/ops.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from .base_agent import BaseAgent
+
+
+class OpsAgent(BaseAgent):
+    """Operations agent for task queues and notifications."""
+
+    def run(self, action: str, payload: Optional[str] = None) -> str:
+        if action == "queue_task":
+            return self.queue_task(payload)
+        if action == "stats":
+            return self.report_stats()
+        if action == "notify":
+            return self.send_notification(payload)
+        return f"[OpsAgent] Unknown action: {action}"
+
+    def queue_task(self, task: Optional[str]) -> str:
+        return f"[OpsAgent] Queued task: {task or 'task'}"
+
+    def report_stats(self) -> str:
+        return "[OpsAgent] Reporting system stats"
+
+    def send_notification(self, message: Optional[str]) -> str:
+        return f"[OpsAgent] Sending notification: {message or 'message'}"
+
+    def handle_task(self, task: str) -> str:
+        return self.run(task)

--- a/core/agents/support.py
+++ b/core/agents/support.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from .base_agent import BaseAgent
+
+
+class SupportAgent(BaseAgent):
+    """Agent for customer service interactions."""
+
+    def run(self, action: str, payload: Optional[str] = None) -> str:
+        if action == "reply_dm":
+            return self.reply_dm(payload)
+        if action == "reply_comment":
+            return self.reply_comment(payload)
+        return f"[SupportAgent] Unknown action: {action}"
+
+    def reply_dm(self, message: Optional[str]) -> str:
+        return f"[SupportAgent] Replying to DM: {message or 'message'}"
+
+    def reply_comment(self, message: Optional[str]) -> str:
+        return f"[SupportAgent] Replying to comment: {message or 'comment'}"
+
+    def handle_task(self, task: str) -> str:
+        return self.run(task)

--- a/core/crm.py
+++ b/core/crm.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List
+
+
+class CRM:
+    """Simple CRM storage backed by a JSON file."""
+
+    def __init__(self, path: str | None = None) -> None:
+        self.path = path or os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "..", "memory", "crm.json"
+        )
+        if os.path.exists(self.path):
+            with open(self.path, "r", encoding="utf-8") as f:
+                self.data: Dict[str, Any] = json.load(f)
+        else:
+            self.data = {
+                "remote100k": {"subs": []},
+                "tradeview_ai": {"demos": []},
+                "app_304": {"leads": []},
+            }
+            self._save()
+
+    def _save(self) -> None:
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(self.data, f, indent=2)
+
+    # --- Remote100K subscribers ---
+    def add_remote100k_sub(self, email: str, plan: str, entry_point: str) -> None:
+        self.data.setdefault("remote100k", {}).setdefault("subs", []).append(
+            {"email": email, "plan": plan, "entry_point": entry_point}
+        )
+        self._save()
+
+    # --- Tradeview demo requests ---
+    def add_tradeview_demo(self, timestamp: str, contact: str) -> None:
+        self.data.setdefault("tradeview_ai", {}).setdefault("demos", []).append(
+            {"timestamp": timestamp, "contact": contact}
+        )
+        self._save()
+
+    # --- TikTok DM leads for 304 App ---
+    def add_tiktok_lead(self, name: str, account: str, source: str) -> None:
+        self.data.setdefault("app_304", {}).setdefault("leads", []).append(
+            {"name": name, "account": account, "source": source}
+        )
+        self._save()
+
+    def get_brand(self, brand: str) -> Any:
+        return self.data.get(brand, {})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.0.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -1967,6 +1968,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3199,6 +3209,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.1.tgz",
+      "integrity": "sha512-jVKHXoWRIsD/qS6lvGveckwb862EekvapdHJN/cGmzw40KnJH5gg53ujOJ4qX6EKIK9LSBfFed/xiQ5yeXNrUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.7.1.tgz",
+      "integrity": "sha512-bavdk2BA5r3MYalGKZ01u8PGuDBloQmzpBZVhDLrOOv1N943Wq6dcM9GhB3x8b7AbqPMEezauv4PeGkAJfy7FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.7.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3264,6 +3312,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/frontend/src/components/ActionPanel.jsx
+++ b/frontend/src/components/ActionPanel.jsx
@@ -1,0 +1,15 @@
+export default function ActionPanel({ actions, onRun }) {
+  return (
+    <div className="flex flex-wrap gap-2 mb-4">
+      {actions.map(a => (
+        <button
+          key={a.action}
+          onClick={() => onRun(a.action)}
+          className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm"
+        >
+          {a.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Link, useLocation } from 'react-router-dom'
 import {
   ChevronDownIcon,
   ChevronRightIcon,
@@ -29,6 +30,7 @@ export default function Sidebar({
 }) {
   const [openKey, setOpenKey] = useState('')
   const [newProjectName, setNewProjectName] = useState('')
+  const location = useLocation()
 
   function toggleBrand(key) {
     setOpenKey(prev => (prev === key ? '' : key))
@@ -106,6 +108,55 @@ export default function Sidebar({
             <PlusIcon className="w-4 h-4" />
           </button>
         </div>
+      </div>
+      <div className="mt-6">
+        <div className="text-sm font-semibold mb-1">Agents</div>
+        <ul className="space-y-1">
+          {[
+            { path: '/agents/growth', label: 'Growth' },
+            { path: '/agents/dev', label: 'Dev' },
+            { path: '/agents/support', label: 'Support' },
+            { path: '/agents/ops', label: 'Ops' },
+          ].map(a => (
+            <li key={a.path}>
+              <Link
+                to={a.path}
+                onClick={() => setSidebarOpen(false)}
+                className={`block px-2 py-1 rounded ${
+                  location.pathname === a.path
+                    ? 'bg-gray-200 dark:bg-gray-800'
+                    : 'hover:bg-gray-200 dark:hover:bg-gray-800'
+                }`}
+              >
+                {a.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="mt-6">
+        <div className="text-sm font-semibold mb-1">CRM</div>
+        <ul className="space-y-1">
+          {[
+            { path: '/crm/remote100k', label: 'Remote100K' },
+            { path: '/crm/tradeview_ai', label: 'Tradeview' },
+            { path: '/crm/app_304', label: '304 App' },
+          ].map(c => (
+            <li key={c.path}>
+              <Link
+                to={c.path}
+                onClick={() => setSidebarOpen(false)}
+                className={`block px-2 py-1 rounded ${
+                  location.pathname === c.path
+                    ? 'bg-gray-200 dark:bg-gray-800'
+                    : 'hover:bg-gray-200 dark:hover:bg-gray-800'
+                }`}
+              >
+                {c.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
       </div>
     </aside>
   )

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,11 +1,25 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
-// Import the new index page instead of the old App
 import IndexPage from './pages/index.jsx'
+import GrowthAgentPage from './pages/agents/Growth.jsx'
+import DevAgentPage from './pages/agents/Dev.jsx'
+import SupportAgentPage from './pages/agents/Support.jsx'
+import OpsAgentPage from './pages/agents/Ops.jsx'
+import CRMPage from './pages/CRM.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <IndexPage />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<IndexPage />} />
+        <Route path="/agents/growth" element={<GrowthAgentPage />} />
+        <Route path="/agents/dev" element={<DevAgentPage />} />
+        <Route path="/agents/support" element={<SupportAgentPage />} />
+        <Route path="/agents/ops" element={<OpsAgentPage />} />
+        <Route path="/crm/:brand" element={<CRMPage />} />
+      </Routes>
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/frontend/src/pages/CRM.jsx
+++ b/frontend/src/pages/CRM.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import Sidebar from '../components/Sidebar.jsx'
+
+export default function CRMPage() {
+  const { brand } = useParams()
+  const [records, setRecords] = useState([])
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch(`/api/crm/${brand}`)
+      const data = await res.json()
+      const list = Object.values(data)[0] || []
+      setRecords(Array.isArray(list) ? list : [])
+    }
+    load()
+  }, [brand])
+
+  return (
+    <div className="flex h-screen">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <main className="flex-1 flex flex-col">
+        <header className="p-4 border-b">CRM for {brand}</header>
+        <div className="p-4 space-y-2 text-sm">
+          {records.map((r, i) => (
+            <pre key={i} className="bg-gray-100 dark:bg-gray-800 p-2 rounded">{JSON.stringify(r, null, 2)}</pre>
+          ))}
+          {records.length === 0 && <div>No records.</div>}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/agents/Dev.jsx
+++ b/frontend/src/pages/agents/Dev.jsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import Sidebar from '../../components/Sidebar.jsx'
+import ChatBox from '../../components/ChatBox.jsx'
+import ActionPanel from '../../components/ActionPanel.jsx'
+
+export default function DevAgentPage() {
+  const [messages, setMessages] = useState([])
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  async function sendMessage(text) {
+    const res = await fetch('/api/agent/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent: 'dev', action: 'chat', input: text })
+    })
+    return res.json()
+  }
+
+  async function runAction(action) {
+    const res = await fetch('/api/agent/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent: 'dev', action })
+    })
+    const data = await res.json()
+    setMessages(m => [...m, { role: 'assistant', content: data.response, timestamp: data.timestamp }])
+  }
+
+  const actions = [
+    { label: 'Write React Component', action: 'react_component' },
+    { label: 'Fix Backend Bug', action: 'fix_backend_bug' },
+    { label: 'Generate Tailwind Card', action: 'tailwind_card' }
+  ]
+
+  return (
+    <div className="flex h-screen">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <main className="flex-1 flex flex-col">
+        <header className="p-4 border-b">Welcome to Dev Agent</header>
+        <div className="flex-1 flex flex-col p-4">
+          <ActionPanel actions={actions} onRun={runAction} />
+          <ChatBox messages={messages} setMessages={setMessages} sendMessage={sendMessage} />
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/agents/Growth.jsx
+++ b/frontend/src/pages/agents/Growth.jsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import Sidebar from '../../components/Sidebar.jsx'
+import ChatBox from '../../components/ChatBox.jsx'
+import ActionPanel from '../../components/ActionPanel.jsx'
+
+export default function GrowthAgentPage() {
+  const [messages, setMessages] = useState([])
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  async function sendMessage(text) {
+    const res = await fetch('/api/agent/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent: 'growth', action: 'chat', input: text })
+    })
+    return res.json()
+  }
+
+  async function runAction(action) {
+    const res = await fetch('/api/agent/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent: 'growth', action })
+    })
+    const data = await res.json()
+    setMessages(m => [...m, { role: 'assistant', content: data.response, timestamp: data.timestamp }])
+  }
+
+  const actions = [
+    { label: 'Make Remote100K Slideshow', action: 'slideshow' },
+    { label: 'Send Follow-Up DM', action: 'dm' },
+    { label: 'Scrape Competitor', action: 'scrape' }
+  ]
+
+  return (
+    <div className="flex h-screen">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <main className="flex-1 flex flex-col">
+        <header className="p-4 border-b">Welcome to Growth Agent</header>
+        <div className="flex-1 flex flex-col p-4">
+          <ActionPanel actions={actions} onRun={runAction} />
+          <ChatBox messages={messages} setMessages={setMessages} sendMessage={sendMessage} />
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/agents/Ops.jsx
+++ b/frontend/src/pages/agents/Ops.jsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import Sidebar from '../../components/Sidebar.jsx'
+import ChatBox from '../../components/ChatBox.jsx'
+import ActionPanel from '../../components/ActionPanel.jsx'
+
+export default function OpsAgentPage() {
+  const [messages, setMessages] = useState([])
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  async function sendMessage(text) {
+    const res = await fetch('/api/agent/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent: 'ops', action: 'chat', input: text })
+    })
+    return res.json()
+  }
+
+  async function runAction(action) {
+    const res = await fetch('/api/agent/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent: 'ops', action })
+    })
+    const data = await res.json()
+    setMessages(m => [...m, { role: 'assistant', content: data.response, timestamp: data.timestamp }])
+  }
+
+  const actions = [
+    { label: 'Queue Task', action: 'queue_task' },
+    { label: 'Show Stats', action: 'stats' },
+    { label: 'Send Notification', action: 'notify' }
+  ]
+
+  return (
+    <div className="flex h-screen">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <main className="flex-1 flex flex-col">
+        <header className="p-4 border-b">Welcome to Ops Agent</header>
+        <div className="flex-1 flex flex-col p-4">
+          <ActionPanel actions={actions} onRun={runAction} />
+          <ChatBox messages={messages} setMessages={setMessages} sendMessage={sendMessage} />
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/agents/Support.jsx
+++ b/frontend/src/pages/agents/Support.jsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import Sidebar from '../../components/Sidebar.jsx'
+import ChatBox from '../../components/ChatBox.jsx'
+import ActionPanel from '../../components/ActionPanel.jsx'
+
+export default function SupportAgentPage() {
+  const [messages, setMessages] = useState([])
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  async function sendMessage(text) {
+    const res = await fetch('/api/agent/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent: 'support', action: 'chat', input: text })
+    })
+    return res.json()
+  }
+
+  async function runAction(action) {
+    const res = await fetch('/api/agent/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent: 'support', action })
+    })
+    const data = await res.json()
+    setMessages(m => [...m, { role: 'assistant', content: data.response, timestamp: data.timestamp }])
+  }
+
+  const actions = [
+    { label: 'Reply to DM', action: 'reply_dm' },
+    { label: 'Reply to Comment', action: 'reply_comment' }
+  ]
+
+  return (
+    <div className="flex h-screen">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <main className="flex-1 flex flex-col">
+        <header className="p-4 border-b">Welcome to Support Agent</header>
+        <div className="flex-1 flex flex-col p-4">
+          <ActionPanel actions={actions} onRun={runAction} />
+          <ChatBox messages={messages} setMessages={setMessages} sendMessage={sendMessage} />
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/memory/agent_memory.json
+++ b/memory/agent_memory.json
@@ -1,0 +1,8 @@
+{
+  "brands": {
+    "remote100k": {},
+    "tradeview_ai": {},
+    "app_304": {}
+  },
+  "actions": []
+}


### PR DESCRIPTION
## Summary
- add Growth, Dev, Support, and Ops agent modules with run methods
- wire Ajax core with persistent memory and CRM backend
- build agent dashboard pages with action buttons and routing

## Testing
- `PYTHONPATH=. pytest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68913a433df48326bd7e655051c03faf