### PR TITLE
Add routes and sidebar links for agent pages and CRM

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -113,10 +113,10 @@ export default function Sidebar({
         <div className="text-sm font-semibold mb-1">Agents</div>
         <ul className="space-y-1">
           {[
-            { path: '/agents/growth', label: 'Growth' },
-            { path: '/agents/dev', label: 'Dev' },
-            { path: '/agents/support', label: 'Support' },
-            { path: '/agents/ops', label: 'Ops' },
+            { path: '/agents/dev', label: 'Dev Agent' },
+            { path: '/agents/growth', label: 'Growth Agent' },
+            { path: '/agents/support', label: 'Support Agent' },
+            { path: '/agents/ops', label: 'Ops Agent' },
           ].map(a => (
             <li key={a.path}>
               <Link
@@ -137,25 +137,19 @@ export default function Sidebar({
       <div className="mt-6">
         <div className="text-sm font-semibold mb-1">CRM</div>
         <ul className="space-y-1">
-          {[
-            { path: '/crm/remote100k', label: 'Remote100K' },
-            { path: '/crm/tradeview_ai', label: 'Tradeview' },
-            { path: '/crm/app_304', label: '304 App' },
-          ].map(c => (
-            <li key={c.path}>
-              <Link
-                to={c.path}
-                onClick={() => setSidebarOpen(false)}
-                className={`block px-2 py-1 rounded ${
-                  location.pathname === c.path
-                    ? 'bg-gray-200 dark:bg-gray-800'
-                    : 'hover:bg-gray-200 dark:hover:bg-gray-800'
-                }`}
-              >
-                {c.label}
-              </Link>
-            </li>
-          ))}
+          <li>
+            <Link
+              to="/crm"
+              onClick={() => setSidebarOpen(false)}
+              className={`block px-2 py-1 rounded ${
+                location.pathname === '/crm'
+                  ? 'bg-gray-200 dark:bg-gray-800'
+                  : 'hover:bg-gray-200 dark:hover:bg-gray-800'
+              }`}
+            >
+              CRM
+            </Link>
+          </li>
         </ul>
       </div>
     </aside>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,22 +3,22 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import IndexPage from './pages/index.jsx'
-import GrowthAgentPage from './pages/agents/Growth.jsx'
-import DevAgentPage from './pages/agents/Dev.jsx'
-import SupportAgentPage from './pages/agents/Support.jsx'
-import OpsAgentPage from './pages/agents/Ops.jsx'
-import CRMPage from './pages/CRM.jsx'
+import Dev from './pages/agents/Dev.jsx'
+import Growth from './pages/agents/Growth.jsx'
+import Support from './pages/agents/Support.jsx'
+import Ops from './pages/agents/Ops.jsx'
+import CRM from './pages/CRM.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<IndexPage />} />
-        <Route path="/agents/growth" element={<GrowthAgentPage />} />
-        <Route path="/agents/dev" element={<DevAgentPage />} />
-        <Route path="/agents/support" element={<SupportAgentPage />} />
-        <Route path="/agents/ops" element={<OpsAgentPage />} />
-        <Route path="/crm/:brand" element={<CRMPage />} />
+        <Route path="/agents/dev" element={<Dev />} />
+        <Route path="/agents/growth" element={<Growth />} />
+        <Route path="/agents/support" element={<Support />} />
+        <Route path="/agents/ops" element={<Ops />} />
+        <Route path="/crm" element={<CRM />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/frontend/src/pages/CRM.jsx
+++ b/frontend/src/pages/CRM.jsx
@@ -8,6 +8,7 @@ export default function CRMPage() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
   useEffect(() => {
+    if (!brand) return
     async function load() {
       const res = await fetch(`/api/crm/${brand}`)
       const data = await res.json()
@@ -21,7 +22,7 @@ export default function CRMPage() {
     <div className="flex h-screen">
       <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
       <main className="flex-1 flex flex-col">
-        <header className="p-4 border-b">CRM for {brand}</header>
+        <header className="p-4 border-b">{brand ? `CRM for ${brand}` : 'CRM'}</header>
         <div className="p-4 space-y-2 text-sm">
           {records.map((r, i) => (
             <pre key={i} className="bg-gray-100 dark:bg-gray-800 p-2 rounded">{JSON.stringify(r, null, 2)}</pre>


### PR DESCRIPTION
## Summary
- Link Dev, Growth, Support, Ops agents and the CRM tab in the sidebar for easy navigation.
- Register routes for the new agent pages and CRM in the main router.
- Make CRM page handle optional brand parameter and show a default header.

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68913f616d9c8326a466662b5044bd24